### PR TITLE
Add clear() to ut_map cache

### DIFF
--- a/inc/cappuccino/ut_map.hpp
+++ b/inc/cappuccino/ut_map.hpp
@@ -243,6 +243,19 @@ public:
         return m_keyed_elements.size();
     }
 
+    /**
+     * Removes all elements from the cache (which are destroyed), leaving the container size 0.
+     */
+    auto clear() -> void
+    {
+        if (!empty())
+        {
+            std::lock_guard guard{m_lock};
+            m_keyed_elements.clear();
+            m_ttl_list.clear();
+        }
+    }
+
 private:
     struct keyed_element;
     struct ttl_element;

--- a/test/test_ut_map.cpp
+++ b/test/test_ut_map.cpp
@@ -602,3 +602,24 @@ TEST_CASE("ut_map Insert only long running test.")
     REQUIRE(blocked > inserted);
     REQUIRE(elapsed >= std::chrono::milliseconds{200});
 }
+
+TEST_CASE("ut_map clear cache.")
+{
+    ut_map<uint64_t, std::string> cache{50ms};
+
+    REQUIRE(cache.empty());
+    REQUIRE(cache.insert(1, "test"));
+    REQUIRE(cache.insert(2, "more tests"));
+    REQUIRE(cache.insert(8, "yet more tests"));
+    cache.clear();
+    REQUIRE(cache.empty());
+    REQUIRE(cache.insert(2, "more tests"));
+    REQUIRE(cache.insert(6, "surprise! more tests!"));
+    auto surprise = cache.find(6);
+    REQUIRE(surprise.has_value());
+    REQUIRE(surprise.value() == "surprise! more tests!");
+    REQUIRE(cache.size() == 2);
+    cache.clear();
+    REQUIRE(cache.empty());
+    REQUIRE(cache.size() == 0);
+}


### PR DESCRIPTION
Same behavior as previously done for other cache.