### PR TITLE
update minimum version to eliminate make compatibility warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(cappuccino CXX)
 
 # Set the githooks directory to auto format and update the readme.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(cappuccino_examples CXX)
 
 ### allow_example ###

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(libcappuccino_tests)
 
 set(LIBCAPPUCCINO_TEST_SOURCE_FILES


### PR DESCRIPTION
cmake 3.0 came out in June 2014 and seems to be a good new minimum threshold, [2.8 has been removed from the documentation links](https://cmake.org/cmake/help/latest/release/index.html).

