### PR TITLE
Rename `sync` to `thread_safe`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/bash
 
 FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .tcc"
 

--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -120,8 +120,8 @@ Currently tested distros:
 *   fedora:latest
 
 Currently tested compilers:
-*   g++-9
-*   clang-9
+*   g++
+*   clang
 
 Contributing a new feature should include relevant tests.  Examples
 are welcome if understanding how the feature works is difficult or provides some additional value the tests otherwise cannot.
@@ -140,7 +140,7 @@ ctest -VV
 
 File bug reports, feature requests and questions using [GitHub Issues](https://github.com/jbaldwin/libcappuccino/issues)
 
-Copyright © 2017-2020, Josh Baldwin
+Copyright © 2017-2023, Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B17-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Currently tested distros:
 *   fedora:latest
 
 Currently tested compilers:
-*   g++-9
-*   clang-9
+*   g++
+*   clang
 
 Contributing a new feature should include relevant tests.  Examples
 are welcome if understanding how the feature works is difficult or provides some additional value the tests otherwise cannot.
@@ -221,7 +221,7 @@ ctest -VV
 
 File bug reports, feature requests and questions using [GitHub Issues](https://github.com/jbaldwin/libcappuccino/issues)
 
-Copyright © 2017-2020, Josh Baldwin
+Copyright © 2017-2023, Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B17-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/examples/bench.cpp
+++ b/examples/bench.cpp
@@ -34,21 +34,21 @@ template<
     size_t cache_size,
     typename key_type,
     typename value_type,
-    sync         sync_type,
+    thread_safe  thread_safe_type,
     batch_insert batch_type>
 static auto tlru_cache_bench_test(std::chrono::seconds ttl) -> void
 {
-    std::mutex                                  cout_lock{};
-    tlru_cache<key_type, value_type, sync_type> cache{cache_size};
+    std::mutex                                         cout_lock{};
+    tlru_cache<key_type, value_type, thread_safe_type> cache{cache_size};
 
     std::cout << "TLRU ";
-    if constexpr (sync_type == sync::yes)
+    if constexpr (thread_safe_type == thread_safe::yes)
     {
-        std::cout << "SYNC ";
+        std::cout << "thread_safe::yes ";
     }
     else
     {
-        std::cout << "UNSYNC ";
+        std::cout << "thread_safe::no ";
     }
 
     auto key_name = "string";
@@ -76,7 +76,8 @@ static auto tlru_cache_bench_test(std::chrono::seconds ttl) -> void
     std::vector<std::thread> workers;
     workers.reserve(worker_count);
 
-    auto func = [&]() mutable -> void {
+    auto func = [&]() mutable -> void
+    {
         size_t worker_iterations = iterations / worker_count;
 
         std::chrono::milliseconds insert_elapsed{0};
@@ -225,21 +226,21 @@ template<
     size_t cache_size,
     typename key_type,
     typename value_type,
-    sync         sync_type,
+    thread_safe  thread_safe_type,
     batch_insert batch_type>
 static auto utlru_cache_bench_test(std::chrono::seconds ttl) -> void
 {
-    std::mutex                                   cout_lock{};
-    utlru_cache<key_type, value_type, sync_type> cache{ttl, cache_size};
+    std::mutex                                          cout_lock{};
+    utlru_cache<key_type, value_type, thread_safe_type> cache{ttl, cache_size};
 
     std::cout << "ULRU ";
-    if constexpr (sync_type == sync::yes)
+    if constexpr (thread_safe_type == thread_safe::yes)
     {
-        std::cout << "SYNC ";
+        std::cout << "thread_safe::yes ";
     }
     else
     {
-        std::cout << "UNSYNC ";
+        std::cout << "thread_safe::no ";
     }
 
     auto key_name = "string";
@@ -266,7 +267,8 @@ static auto utlru_cache_bench_test(std::chrono::seconds ttl) -> void
     std::vector<std::thread> workers;
     workers.reserve(worker_count);
 
-    auto func = [&]() mutable -> void {
+    auto func = [&]() mutable -> void
+    {
         size_t worker_iterations = iterations / worker_count;
 
         std::chrono::milliseconds insert_elapsed{0};
@@ -415,21 +417,21 @@ template<
     size_t cache_size,
     typename key_type,
     typename value_type,
-    sync         sync_type,
+    thread_safe  thread_safe_type,
     batch_insert batch_type>
 static auto lru_cache_bench_test() -> void
 {
-    std::mutex                                 cout_lock{};
-    lru_cache<key_type, value_type, sync_type> cache{cache_size};
+    std::mutex                                        cout_lock{};
+    lru_cache<key_type, value_type, thread_safe_type> cache{cache_size};
 
     std::cout << "LRU ";
-    if constexpr (sync_type == sync::yes)
+    if constexpr (thread_safe_type == thread_safe::yes)
     {
-        std::cout << "SYNC ";
+        std::cout << "thread_safe::yes ";
     }
     else
     {
-        std::cout << "UNSYNC ";
+        std::cout << "thread_safe::no ";
     }
 
     auto key_name = "string";
@@ -456,7 +458,8 @@ static auto lru_cache_bench_test() -> void
     std::vector<std::thread> workers;
     workers.reserve(worker_count);
 
-    auto func = [&]() mutable -> void {
+    auto func = [&]() mutable -> void
+    {
         size_t worker_iterations = iterations / worker_count;
 
         std::chrono::milliseconds insert_elapsed{0};
@@ -606,46 +609,124 @@ int main(int argc, char* argv[])
     constexpr size_t cache_size   = 100'000;
 
     /**
-     * SYNC INDIVIDUAL
+     * thread_safe::yes INDIVIDUAL
      */
-    tlru_cache_bench_test<iterations, worker_count, cache_size, std::string, std::string, sync::yes, batch_insert::no>(
-        10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, std::string, std::string, sync::yes, batch_insert::no>(
-        10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, std::string, std::string, sync::yes, batch_insert::no>();
-    std::cout << "\n";
-
-    tlru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::no>(
-        10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::no>(
-        10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::no>();
-    std::cout << "\n";
-
-    tlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::no>(10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::no>(10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::no>();
-    std::cout << "\n";
-
-    tlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::no>(
-        10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::no>(
-        10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::no>();
-    std::cout << "\n";
-
-    /**
-     * SYNC BATCH
-     */
-    tlru_cache_bench_test<iterations, worker_count, cache_size, std::string, std::string, sync::yes, batch_insert::yes>(
-        10s);
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        std::string,
+        thread_safe::yes,
+        batch_insert::no>(10s);
     utlru_cache_bench_test<
         iterations,
         worker_count,
         cache_size,
         std::string,
         std::string,
-        sync::yes,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        std::string,
+        thread_safe::yes,
+        batch_insert::no>();
+    std::cout << "\n";
+
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::no>();
+    std::cout << "\n";
+
+    tlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, thread_safe::yes, batch_insert::no>(
+        10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::no>();
+    std::cout << "\n";
+
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::no>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::no>();
+    std::cout << "\n";
+
+    /**
+     * SYNC BATCH
+     */
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        std::string,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        std::string,
+        thread_safe::yes,
         batch_insert::yes>(10s);
     lru_cache_bench_test<
         iterations,
@@ -653,73 +734,133 @@ int main(int argc, char* argv[])
         cache_size,
         std::string,
         std::string,
-        sync::yes,
+        thread_safe::yes,
         batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::yes>(
-        10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::yes>(
-        10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, std::string, uint64_t, sync::yes, batch_insert::yes>();
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        std::string,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::yes>(10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::yes>(10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, uint64_t, sync::yes, batch_insert::yes>();
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        uint64_t,
+        thread_safe::yes,
+        batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::yes>(
-        10s);
-    utlru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::yes>(
-        10s);
-    lru_cache_bench_test<iterations, worker_count, cache_size, uint64_t, std::string, sync::yes, batch_insert::yes>();
+    tlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    utlru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::yes>(10s);
+    lru_cache_bench_test<
+        iterations,
+        worker_count,
+        cache_size,
+        uint64_t,
+        std::string,
+        thread_safe::yes,
+        batch_insert::yes>();
     std::cout << "\n";
 
     /**
-     * UNSYNC INDIVIDUAL
+     * thread_safe::no INDIVIDUAL
      */
-    tlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::no>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::no>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::no>();
+    tlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::no>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::no>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::no>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::no>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::no>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::no>();
+    tlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::no>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::no>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::no>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::no>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::no>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::no>();
+    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::no>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::no>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::no>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::no>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::no>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::no>();
+    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::no>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::no>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::no>();
     std::cout << "\n";
 
     /**
-     * UNSYNC BATCH
+     * thread_safe::no BATCH
      */
-    tlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::yes>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::yes>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, sync::no, batch_insert::yes>();
+    tlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::yes>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::yes>(
+        10s);
+    lru_cache_bench_test<iterations, 1, cache_size, std::string, std::string, thread_safe::no, batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::yes>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::yes>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, sync::no, batch_insert::yes>();
+    tlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::yes>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::yes>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, std::string, uint64_t, thread_safe::no, batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::yes>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::yes>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, sync::no, batch_insert::yes>();
+    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::yes>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::yes>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, uint64_t, thread_safe::no, batch_insert::yes>();
     std::cout << "\n";
 
-    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::yes>(10s);
-    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::yes>(10s);
-    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, sync::no, batch_insert::yes>();
+    tlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::yes>(10s);
+    utlru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::yes>(10s);
+    lru_cache_bench_test<iterations, 1, cache_size, uint64_t, std::string, thread_safe::no, batch_insert::yes>();
     std::cout << "\n";
 
     return 0;

--- a/inc/cappuccino/fifo_cache.hpp
+++ b/inc/cappuccino/fifo_cache.hpp
@@ -16,16 +16,16 @@ namespace cappuccino
  * Each key value pair is evicted based on being the first in first out policy, and no other
  * criteria.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class fifo_cache
 {
 private:
@@ -374,8 +374,8 @@ private:
         return {};
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/lfu_cache.hpp
+++ b/inc/cappuccino/lfu_cache.hpp
@@ -16,16 +16,16 @@ namespace cappuccino
  * Each key value pair is evicted based on being the least frequently used, and no other
  * criteria.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash() and operator<().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class lfu_cache
 {
 private:
@@ -349,8 +349,8 @@ private:
         }
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/lfuda_cache.hpp
+++ b/inc/cappuccino/lfuda_cache.hpp
@@ -21,16 +21,16 @@ namespace cappuccino
  * a period of time.  The dynamic age tick count as well as the ratio can be tuned by the
  * user of the cache.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash() and operator<()
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class lfuda_cache
 {
 private:
@@ -457,8 +457,8 @@ private:
         return aged;
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/lock.hpp
+++ b/inc/cappuccino/lock.hpp
@@ -6,37 +6,37 @@
 namespace cappuccino
 {
 /**
- * Determines if the cache should use synchronization or not.
+ * Determines if the cache should use thread safe synchronization or not.
  * By default all caches use synchronization for multi-threaded accesses.
- * By using sync::no you can disable locking internally on the caches, this should
+ * By using thread_safe::no you can disable locking internally on the caches, this should
  * really only be used if you implemented your own locking strategy or the cache
  * in question is owned and used by a single thread.
  */
-enum class sync
+enum class thread_safe
 {
-    /// No synchronization.
+    /// No synchronization, not thread safe but faster if you are using 1 dedicated thread.
     no = 0,
-    /// synchronization via locks.
+    /// Thread safe synchronization via locks.
     yes = 1,
 };
 
-auto to_string(sync s) -> const std::string&;
+auto to_string(thread_safe ts) -> const std::string&;
 
 /**
- * Creates a lock that based on the sync will behave correctly.
- * sync::yes => Uses a std::mutex
- * sync::no => is a no-op.
+ * Creates a lock that based on the thread_safety will behave correctly.
+ * thread_safe::yes => Uses a std::mutex
+ * thread_safe::no => is a no-op.
  *
- * @tparam sync_type The sync type to use.
+ * @tparam thread_safe_type The thread_safe type to use.
  * @tparam lock_type The underlying lock type to use.  Must support .lock() and .unlock().
  */
-template<sync sync_type, typename lock_type = std::mutex>
+template<thread_safe thread_safe_type, typename lock_type = std::mutex>
 class mutex
 {
 public:
     constexpr auto lock() -> void
     {
-        if constexpr (sync_type == sync::yes)
+        if constexpr (thread_safe_type == thread_safe::yes)
         {
             m_lock.lock();
         }
@@ -44,7 +44,7 @@ public:
 
     constexpr auto unlock() -> void
     {
-        if constexpr (sync_type == sync::yes)
+        if constexpr (thread_safe_type == thread_safe::yes)
         {
             m_lock.unlock();
         }

--- a/inc/cappuccino/lru_cache.hpp
+++ b/inc/cappuccino/lru_cache.hpp
@@ -16,16 +16,16 @@ namespace cappuccino
  * Each key value pair is evicted based on being the least recently used, and no other
  * criteria.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class lru_cache
 {
 private:
@@ -323,8 +323,8 @@ private:
         }
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/mru_cache.hpp
+++ b/inc/cappuccino/mru_cache.hpp
@@ -15,16 +15,16 @@ namespace cappuccino
  * Each key value pair is evicted based on being the most recently used, and no other
  * criteria.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class mru_cache
 {
 private:
@@ -320,8 +320,8 @@ private:
         }
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/rr_cache.hpp
+++ b/inc/cappuccino/rr_cache.hpp
@@ -13,16 +13,16 @@ namespace cappuccino
  * Random Replacement (RR) Cache.
  * Each key value pair is evicted based upon a random eviction strategy.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization used NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches
  *                  specific to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class rr_cache
 {
 private:
@@ -303,8 +303,8 @@ private:
         }
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The main store for the key value pairs and metadata for each e.
     std::vector<element> m_elements;

--- a/inc/cappuccino/tlru_cache.hpp
+++ b/inc/cappuccino/tlru_cache.hpp
@@ -21,16 +21,16 @@ namespace cappuccino
  * and least recently used policy.  Expired key value pairs are evicted before
  * least recently used.
  *
- * This cache is sync aware by default and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware by default and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash() and operator<().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class tlru_cache
 {
     using keyed_iterator = typename std::unordered_map<key_type, size_t>::iterator;
@@ -427,8 +427,8 @@ private:
         }
     }
 
-    /// Cache lock for all mutations if sync is enabled.
-    mutex<sync_type> m_lock;
+    /// Cache lock for all mutations if thread_safe is enabled.
+    mutex<thread_safe_type> m_lock;
 
     /// The current number of elements in the cache.
     size_t m_used_size{0};

--- a/inc/cappuccino/ut_map.hpp
+++ b/inc/cappuccino/ut_map.hpp
@@ -25,16 +25,16 @@ namespace cappuccino
  * performance during these operations if N elements are reaching their TTLs and
  * being evicted at once.
  *
- * This map is sync aware and can be used concurrently from multiple threads
- * safely. To remove locks/synchronization use sync::no when creating the cache.
+ * This map is thread_safe aware and can be used concurrently from multiple threads
+ * safely. To remove locks/synchronization use thread_safe::no when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if
  * your data structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this map is thread safe, can be disabled for maps
+ * @tparam thread_safe_type By default this map is thread safe, can be disabled for maps
  * specific to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class ut_map
 {
 public:
@@ -379,7 +379,7 @@ private:
     }
 
     /// Thread lock for all mutations.
-    mutex<sync_type> m_lock;
+    mutex<thread_safe_type> m_lock;
 
     /// The keyed lookup data structure, the value is the keyed_element struct
     /// which includes the value and an iterator to the associated m_ttl_list

--- a/inc/cappuccino/ut_set.hpp
+++ b/inc/cappuccino/ut_set.hpp
@@ -25,14 +25,14 @@ namespace cappuccino
  * performance during these operations if N elements are reaching their TTLs and
  * being evicted at once.
  *
- * This set is sync aware and can be used concurrently from multiple threads
- * safely. To remove locks/synchronization use sync::no when creating the cache.
+ * This set is thread_safe aware and can be used concurrently from multiple threads
+ * safely. To remove locks/synchronization use thread_safe::no when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
- * @tparam sync_type By default this set is thread safe, can be disabled for sets
+ * @tparam thread_safe_type By default this set is thread safe, can be disabled for sets
  * specific to a single thread.
  */
-template<typename key_type, sync sync_type = sync::yes>
+template<typename key_type, thread_safe thread_safe_type = thread_safe::yes>
 class ut_set
 {
 public:
@@ -352,7 +352,7 @@ private:
     }
 
     /// Thread lock for all mutations.
-    mutex<sync_type> m_lock;
+    mutex<thread_safe_type> m_lock;
 
     /// The keyed lookup data structure, the value is the keyed_element struct
     /// which is an iterator to the associated m_ttl_list TTlElement.

--- a/inc/cappuccino/utlru_cache.hpp
+++ b/inc/cappuccino/utlru_cache.hpp
@@ -21,16 +21,16 @@ namespace cappuccino
  * efficient in managing the TTLs since they are uniform for all key value pairs
  * in the cache, rather than tracking items individually.
  *
- * This cache is sync aware and can be used concurrently from multiple threads safely.
+ * This cache is thread_safe aware and can be used concurrently from multiple threads safely.
  * To remove locks/synchronization use NO when creating the cache.
  *
  * @tparam key_type The key type.  Must support std::hash().
  * @tparam value_type The value type.  This is returned by copy on a find, so if your data
  *                   structure value is large it is advisable to store in a shared ptr.
- * @tparam sync_type By default this cache is thread safe, can be disabled for caches specific
+ * @tparam thread_safe_type By default this cache is thread safe, can be disabled for caches specific
  *                  to a single thread.
  */
-template<typename key_type, typename value_type, sync sync_type = sync::yes>
+template<typename key_type, typename value_type, thread_safe thread_safe_type = thread_safe::yes>
 class utlru_cache
 {
     using keyed_iterator = typename std::unordered_map<key_type, size_t>::iterator;
@@ -454,7 +454,7 @@ private:
     }
 
     /// Cache lock for all mutations.
-    mutex<sync_type> m_lock;
+    mutex<thread_safe_type> m_lock;
 
     /// The uniform TTL for every key value pair inserted into the cache.
     std::chrono::milliseconds m_ttl;

--- a/src/lock.cpp
+++ b/src/lock.cpp
@@ -4,20 +4,20 @@ namespace cappuccino
 {
 using namespace std::string_literals;
 
-static const std::string sync_invalid_value = "invalid_value"s;
-static const std::string sync_no            = "no"s;
-static const std::string sync_yes           = "yes"s;
+static const std::string thread_safe_invalid_value = "invalid_value"s;
+static const std::string thread_safe_no            = "no"s;
+static const std::string thread_safe_yes           = "yes"s;
 
-auto to_string(sync s) -> const std::string&
+auto to_string(thread_safe ts) -> const std::string&
 {
-    switch (s)
+    switch (ts)
     {
-        case sync::no:
-            return sync_no;
-        case sync::yes:
-            return sync_yes;
+        case thread_safe::no:
+            return thread_safe_no;
+        case thread_safe::yes:
+            return thread_safe_yes;
         default:
-            return sync_invalid_value;
+            return thread_safe_invalid_value;
     }
 }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -15,9 +15,9 @@ TEST_CASE("InsertMethod to_string()")
 
 TEST_CASE("syncImpl to_string()")
 {
-    REQUIRE(to_string(sync::yes) == "yes");
-    REQUIRE(to_string(sync::no) == "no");
-    REQUIRE(to_string(static_cast<cappuccino::sync>(5000)) == "invalid_value");
+    REQUIRE(to_string(thread_safe::yes) == "yes");
+    REQUIRE(to_string(thread_safe::no) == "no");
+    REQUIRE(to_string(static_cast<cappuccino::thread_safe>(5000)) == "invalid_value");
 }
 
 TEST_CASE("peek to_string()")


### PR DESCRIPTION
`sync` is a bit more ambigious than `thread_safe`. This should make it easier as a user of the library to know what the template parameter is for.

Closes #23